### PR TITLE
[feature #163385683] add page to view all contesting

### DIFF
--- a/UI/politicians-for-office.html
+++ b/UI/politicians-for-office.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>  Politico - progress through tranparency</title>
+  <link rel="stylesheet" type="text/css" href="styles/politico.css">
+</head>
+<body>
+
+<nav>
+    <a class="nav-brand nav-brand-admin " href="#"> Politico </a>
+</nav>
+<div class="profile-container">
+  <div class="user-profile-left"> 
+    <div class="profile-image">
+      <img src="images/profileImage.jpg" alt="profile_img"> 
+      <p> Aniebiet Udoh <br> <span> [admin] </span> 
+        <a href="#"><span> logout </span></a>
+      </p>
+    </div>
+
+    <div class="user-profile-nav">
+      <ul>
+        <li><a href="add-party.html"> 
+          <span><i class="fas fa-plus-square"></i> Add new political party </span></a>
+        </li>
+        <li><a href="view-parties.html"> 
+          <span><i class="far fa-eye"></i> View all political party </span> </a>
+        </li>
+         <li><a href="add-office.html"> 
+          <span><i class="fas fa-plus-square"></i> Add new political office </span></a>
+        </li>
+        <li><a href="#"> 
+          <span><i class="far fa-eye"></i> View all office office </span> </a>
+        </li>
+        <li><a href="politicians-for-office.html"> 
+          <span><i class="far fa-eye"></i> Contestants per office </span> </a>
+        </li>
+        <li><a href="contest.html"> 
+          <span><i class="fas fa-person-booth"></i> Run for political office </span> </a>
+        </li>
+
+      </ul>
+    </div>
+
+  </div>
+  <div class="user-profile-right">
+    <h3> View all politicians running for an office</h3>
+<form class="ui-form modal-content modal-content-dashboard" method="post">
+    <p>
+      <label> Select political office</label><br><br>
+       <select>
+          <option value="volvo"> Presidency </option>
+          <option value="saab"> Governor </option>
+          <option value="opel"> LGA Chairman</option>
+          <option value="audi"> Senetor </option>
+        </select>
+    </p><br>
+</form>
+<table>
+  <tr>
+    <th>ID</th>
+    <th>Name</th>
+    <th>HQ Address</th>
+    <th>Logo</th>
+  </tr>
+  <tr>
+    <td>1</td>
+    <td>PDP</td>
+    <td>Germany</td>
+    <td>Ukrain</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>PPC</td>
+    <td>Mexico</td>
+    <td>Italy</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>APC</td>
+    <td>Austria</td>
+    <td>Nigeria</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>APGA</td>
+    <td>UK</td>
+    <td>Isreal</td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>NNPP</td>
+    <td>Cambodia</td>
+    <td>Canada</td>
+  </tr>
+  <tr>
+    <td>6</td>
+    <td>SDP</td>
+    <td>Italy</td>
+    <td>Thailand</td>
+  </tr>
+</table>
+  </div>
+</div>
+
+  <script type="text/javascript" src="scripts/modal.js"></script>
+</body>
+</html>


### PR DESCRIPTION
**What does this PR do?**
This pull request implements a page where user can view all politicians running for a particular office.

**Description of Task to be completed?**
The user see all politicians running for a particular office after selecting the office

**How should this be manually tested?**
This template is still under construction and will be hosted on GitHub Pages

**What are the relevant pivotal tracker stories?**
#163385683

**Any background context you want to add?**
None